### PR TITLE
BC-11775 - update sanitize-html to 2.17.4+ due to CVE-2026-44990 (XXS vulnerbility)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
 				"reflect-metadata": "^0.2.2",
 				"response-time": "^2.3.4",
 				"rxjs": "^7.8.2",
-				"sanitize-html": "^2.17.2",
+				"sanitize-html": "^2.17.4",
 				"winston": "^3.19.0"
 			},
 			"devDependencies": {
@@ -9303,6 +9303,12 @@
 			"integrity": "sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA==",
 			"license": "MIT"
 		},
+		"node_modules/dayjs": {
+			"version": "1.11.20",
+			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+			"integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+			"license": "MIT"
+		},
 		"node_modules/debug": {
 			"version": "4.4.3",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -12681,6 +12687,15 @@
 			"integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
 			"license": "MIT"
 		},
+		"node_modules/launder": {
+			"version": "1.7.1",
+			"resolved": "https://registry.npmjs.org/launder/-/launder-1.7.1.tgz",
+			"integrity": "sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==",
+			"license": "MIT",
+			"dependencies": {
+				"dayjs": "^1.11.7"
+			}
+		},
 		"node_modules/lazystream": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
@@ -14817,15 +14832,16 @@
 			"license": "MIT"
 		},
 		"node_modules/sanitize-html": {
-			"version": "2.17.3",
-			"resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.3.tgz",
-			"integrity": "sha512-Kn4srCAo2+wZyvCNKCSyB2g8RQ8IkX/gQs2uqoSRNu5t9I2qvUyAVvRDiFUVAiX3N3PNuwStY0eNr+ooBHVWEg==",
+			"version": "2.17.4",
+			"resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.4.tgz",
+			"integrity": "sha512-2HW7v2ol/uAM7sX4hbD8Z59OGWmAPrvjL8E71UWlBcj6m+kcF6ilQBLny+cIgY214QJeJT5tQuxKKqX0SQqjGQ==",
 			"license": "MIT",
 			"dependencies": {
 				"deepmerge": "^4.2.2",
 				"escape-string-regexp": "^4.0.0",
 				"htmlparser2": "^10.1.0",
 				"is-plain-object": "^5.0.0",
+				"launder": "^1.7.1",
 				"parse-srcset": "^1.0.2",
 				"postcss": "^8.3.11"
 			}

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
 		"@aws-sdk/client-s3": "^3.1025.0",
 		"@aws-sdk/lib-storage": "^3.1025.0",
 		"@aws-sdk/util-retry": "^3.374.0",
-		"@smithy/node-http-handler": "^4.6.0",
 		"@golevelup/nestjs-rabbitmq": "^9.0.0",
 		"@mikro-orm/core": "^6.6.11",
 		"@mikro-orm/mongodb": "^6.6.11",
@@ -50,6 +49,7 @@
 		"@nestjs/passport": "^11.0.5",
 		"@nestjs/platform-express": "^11.1.18",
 		"@nestjs/swagger": "^11.2.6",
+		"@smithy/node-http-handler": "^4.6.0",
 		"@xmldom/xmldom": "^0.9.9",
 		"archiver": "^7.0.1",
 		"axios": "^1.14.0",
@@ -69,7 +69,7 @@
 		"reflect-metadata": "^0.2.2",
 		"response-time": "^2.3.4",
 		"rxjs": "^7.8.2",
-		"sanitize-html": "^2.17.2",
+		"sanitize-html": "^2.17.4",
 		"winston": "^3.19.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
# Description
see for details
https://github.com/advisories/GHSA-rpr9-rxv7-x643

hint: there is no tag to be found in https://github.com/apostrophecms/apostrophe with version 2.17.4 weirdly enough, but it exists in npmjs see also https://github.com/apostrophecms/apostrophe/issues/5418#issuecomment-4500334033
commit that fixes the issue in the library
https://github.com/apostrophecms/apostrophe/commit/8d4c882b4ed3a7ce802cd87f89f0c1cb7482b8c2
<!--
  This is a template to add as much information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:
    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and Integration), also for error cases
    - Main logic should be hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the beginning of development; they also have to accept them at the end
    - Keep the changelog up-to-date
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests
BC-11775
<!-- related-prs-and-tickets-start -->
<!-- related-prs-and-tickets-end -->

## Screenshots of UI changes

<!--
  only needed for visual changes
  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [ ] DEV: If the API or client code was changed, all necessary code generation or synchronization steps were completed and tested.
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

