### PR TITLE
BC-11883 - Add isServiceAccount property to user and JWT interfaces, and update related tests

### DIFF
--- a/src/infra/auth-guard/decorator/jwt-auth.decorator.spec.ts
+++ b/src/infra/auth-guard/decorator/jwt-auth.decorator.spec.ts
@@ -97,6 +97,7 @@ describe('Decorators', () => {
 				const expectedCurrentUser = {
 					accountId: currentUser.accountId,
 					isExternalUser: false,
+					isServiceAccount: false,
 					roles: [...currentUser.roles],
 					schoolId: currentUser.schoolId,
 					support: false,

--- a/src/infra/auth-guard/interface/jwt-payload.ts
+++ b/src/infra/auth-guard/interface/jwt-payload.ts
@@ -7,6 +7,7 @@ export interface CreateJwtPayload {
 	support: boolean;
 	supportUserId?: string;
 	isExternalUser: boolean;
+	isServiceAccount: boolean;
 }
 
 export interface JwtPayload extends CreateJwtPayload {

--- a/src/infra/auth-guard/interface/user.ts
+++ b/src/infra/auth-guard/interface/user.ts
@@ -21,5 +21,7 @@ export interface CurrentUserInterface {
 	/** True if the user is an external user e.g. an oauth user or ldap user */
 	isExternalUser: boolean;
 
+	isServiceAccount: boolean;
+
 	externalIdToken?: string;
 }

--- a/src/infra/auth-guard/mapper/current-user.factory.spec.ts
+++ b/src/infra/auth-guard/mapper/current-user.factory.spec.ts
@@ -32,6 +32,7 @@ describe('CurrentUserBuilder', () => {
 				roles: requiredProps.roles,
 				support: false,
 				isExternalUser: false,
+				isServiceAccount: false,
 				systemId: undefined,
 				externalIdToken: undefined,
 			});
@@ -50,6 +51,7 @@ describe('CurrentUserBuilder', () => {
 					roles: requiredProps.roles,
 					support: true,
 					isExternalUser: false,
+					isServiceAccount: false,
 					systemId: undefined,
 					externalIdToken: undefined,
 				});
@@ -69,6 +71,7 @@ describe('CurrentUserBuilder', () => {
 					roles: requiredProps.roles,
 					support: false,
 					isExternalUser: true,
+					isServiceAccount: false,
 					systemId: undefined,
 					externalIdToken: undefined,
 				});
@@ -89,6 +92,7 @@ describe('CurrentUserBuilder', () => {
 					roles: requiredProps.roles,
 					support: false,
 					isExternalUser: false,
+					isServiceAccount: false,
 					systemId,
 					externalIdToken: undefined,
 				});
@@ -109,8 +113,65 @@ describe('CurrentUserBuilder', () => {
 					roles: requiredProps.roles,
 					support: false,
 					isExternalUser: true,
+					isServiceAccount: false,
 					systemId: undefined,
 					externalIdToken,
+				});
+			});
+		});
+
+		describe('when asServiceAccount is executed', () => {
+			it('should set isServiceAccount to true when called with true', () => {
+				const { requiredProps } = setup();
+
+				const currentUser = new CurrentUserBuilder(requiredProps).asServiceAccount(true).build();
+
+				expect(currentUser).toMatchObject<CurrentUserInterface>({
+					userId: requiredProps.userId,
+					schoolId: requiredProps.schoolId,
+					accountId: requiredProps.accountId,
+					roles: requiredProps.roles,
+					support: false,
+					isExternalUser: false,
+					isServiceAccount: true,
+					systemId: undefined,
+					externalIdToken: undefined,
+				});
+			});
+
+			it('should not set isServiceAccount when called with false', () => {
+				const { requiredProps } = setup();
+
+				const currentUser = new CurrentUserBuilder(requiredProps).asServiceAccount(false).build();
+
+				expect(currentUser).toMatchObject<CurrentUserInterface>({
+					userId: requiredProps.userId,
+					schoolId: requiredProps.schoolId,
+					accountId: requiredProps.accountId,
+					roles: requiredProps.roles,
+					support: false,
+					isExternalUser: false,
+					isServiceAccount: false,
+					systemId: undefined,
+					externalIdToken: undefined,
+				});
+			});
+
+			it('should not set isServiceAccount when called with undefined', () => {
+				const { requiredProps } = setup();
+
+				const currentUser = new CurrentUserBuilder(requiredProps).asServiceAccount(undefined).build();
+
+				expect(currentUser).toMatchObject<CurrentUserInterface>({
+					userId: requiredProps.userId,
+					schoolId: requiredProps.schoolId,
+					accountId: requiredProps.accountId,
+					roles: requiredProps.roles,
+					support: false,
+					isExternalUser: false,
+					isServiceAccount: false,
+					systemId: undefined,
+					externalIdToken: undefined,
 				});
 			});
 		});

--- a/src/infra/auth-guard/mapper/current-user.factory.ts
+++ b/src/infra/auth-guard/mapper/current-user.factory.ts
@@ -32,6 +32,7 @@ export class CurrentUserBuilder {
 			roles: this.requiredProps.roles,
 			support: false,
 			isExternalUser: false,
+			isServiceAccount: false,
 			systemId: undefined,
 			externalIdToken: undefined,
 		};
@@ -70,6 +71,14 @@ export class CurrentUserBuilder {
 	public asExternalUserWithToken(externalIdToken: string): this {
 		this.props.externalIdToken = externalIdToken;
 		this.props.isExternalUser = true;
+
+		return this;
+	}
+
+	public asServiceAccount(isServiceAccount?: boolean): this {
+		if (isServiceAccount === true) {
+			this.props.isServiceAccount = isServiceAccount;
+		}
 
 		return this;
 	}

--- a/src/infra/auth-guard/mapper/jwt.factory.spec.ts
+++ b/src/infra/auth-guard/mapper/jwt.factory.spec.ts
@@ -18,6 +18,7 @@ describe('JwtPayloadFactory', () => {
 				userId: currentUser.userId,
 				support: false,
 				isExternalUser: false,
+				isServiceAccount: false,
 			});
 		});
 	});
@@ -38,6 +39,7 @@ describe('JwtPayloadFactory', () => {
 				support: true,
 				supportUserId,
 				isExternalUser: false,
+				isServiceAccount: false,
 			});
 		});
 	});

--- a/src/infra/auth-guard/mapper/jwt.factory.ts
+++ b/src/infra/auth-guard/mapper/jwt.factory.ts
@@ -16,6 +16,7 @@ export class JwtPayloadFactory {
 			support: false,
 			supportUserId: undefined,
 			isExternalUser: currentUser.isExternalUser,
+			isServiceAccount: currentUser.isServiceAccount,
 		};
 
 		const createJwtPayload = JwtPayloadFactory.build(data);
@@ -33,6 +34,7 @@ export class JwtPayloadFactory {
 			support: true,
 			supportUserId,
 			isExternalUser: currentUser.isExternalUser,
+			isServiceAccount: currentUser.isServiceAccount,
 		};
 
 		const createJwtPayload = JwtPayloadFactory.build(data);

--- a/src/infra/auth-guard/testing/jwtpayload.factory.ts
+++ b/src/infra/auth-guard/testing/jwtpayload.factory.ts
@@ -19,6 +19,8 @@ class JwtPayloadImpl implements JwtPayload {
 
 	isExternalUser: boolean;
 
+	isServiceAccount: boolean;
+
 	aud: string;
 
 	exp: number;
@@ -39,6 +41,7 @@ class JwtPayloadImpl implements JwtPayload {
 		this.systemId = data.systemId ?? '';
 		this.support = data.support || false;
 		this.isExternalUser = data.isExternalUser;
+		this.isServiceAccount = data.isServiceAccount || false;
 		this.supportUserId = data.supportUserId;
 		this.aud = data.aud;
 		this.exp = data.exp;
@@ -60,6 +63,7 @@ export const jwtPayloadFactory = JwtPayloadFactory.define(JwtPayloadImpl, ({ seq
 		systemId: new ObjectId().toHexString(),
 		support: true,
 		isExternalUser: true,
+		isServiceAccount: false,
 		sub: `sub-${sequence}`,
 		jti: `jit-${sequence}`,
 		aud: `aud-${sequence}`,

--- a/src/testing/factory/currentuser.factory.ts
+++ b/src/testing/factory/currentuser.factory.ts
@@ -15,6 +15,8 @@ export class CurrentUser implements CurrentUserInterface {
 
 	public isExternalUser: boolean;
 
+	public isServiceAccount: boolean;
+
 	public support: boolean;
 
 	public supportUserId?: string;
@@ -26,6 +28,7 @@ export class CurrentUser implements CurrentUserInterface {
 		this.accountId = data.accountId;
 		this.systemId = data.systemId ?? '';
 		this.isExternalUser = data.isExternalUser;
+		this.isServiceAccount = data.isServiceAccount;
 		this.support = false;
 		this.supportUserId = data.supportUserId;
 	}
@@ -59,6 +62,7 @@ export const currentUserFactory = CurrentUserFactory.define(CurrentUser, () => {
 		accountId: new ObjectId().toHexString(),
 		systemId: new ObjectId().toHexString(),
 		isExternalUser: false,
+		isServiceAccount: false,
 		support: false,
 		supportUserId: undefined,
 	};


### PR DESCRIPTION
# Description

<!--
  This is a template to add as much information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:
    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and Integration), also for error cases
    - Main logic should be hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the beginning of development; they also have to accept them at the end
    - Keep the changelog up-to-date
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests
JIRA :
- https://ticketsystem.dbildungscloud.de/browse/BC-11883

Related PRs :
- https://github.com/hpi-schul-cloud/h5p-server/pull/46

Deployments :
- http://bc-11883.dbc.dbildungscloud.dev/
- http://bc-11883.brb.dbildungscloud.dev/
- http://bc-11883.nbc.dbildungscloud.dev/
- http://bc-11883.thr.dbildungscloud.dev/

<!-- related-prs-and-tickets-start -->
<!-- related-prs-and-tickets-end -->

## Screenshots of UI changes

<!--
  only needed for visual changes
  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [ ] DEV: If the API or client code was changed, all necessary code generation or synchronization steps were completed and tested.
- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

